### PR TITLE
Required parameter follows optional parameter error in Kleeja functions.php and usr.php files

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -892,7 +892,7 @@ function delete_config($name)
 //
 //update words to lang
 //
-function update_olang($name, $lang = 'en', $value)
+function update_olang($name, $value, $lang = 'en')
 {
     global $SQL, $dbprefix, $olang;
 

--- a/includes/usr.php
+++ b/includes/usr.php
@@ -55,7 +55,7 @@ class usrcp
     }
 
     //now our table, normal user system
-    public function normal($name, $pass, $hashed = false, $expire, $loginadm = false)
+    public function normal($name, $pass, $expire, $hashed = false, $loginadm = false)
     {
         global $SQL, $dbprefix, $config, $userinfo;
 


### PR DESCRIPTION
## Description

This pull request fixes a "Required parameter follows optional parameter" error that occurs in the `functions.php` and `usr.php` files when running Kleeja with PHP 8.0. The error is caused by the function parameters being defined in a way that is no longer supported in PHP 8.0.

To fix the error, I modified the affected functions to ensure that required parameters come before optional parameters. Specifically, I moved the `$expire` parameter before the `$hashed` parameter in the `normal` function in `usr.php`, and moved the `$value` parameter before the `$lang` parameter in the `update_olang` function in `functions.php`.

## Changes Made

- Moved `$expire` parameter before `$hashed` parameter in `normal` function in `usr.php`.
- Moved `$value` parameter before `$lang` parameter in `update_olang` function in `functions.php`.

## Checklist

- [x] Tested changes on local instance of Kleeja running PHP 8.0
- [x] Confirmed that the "Required parameter follows optional parameter" error no longer occurs

## Related Issues

This pull request resolves [issue #222](https://github.com/hmdqr/kleeja/issues/222).
