### PR TITLE
Fix PHP 8.2 error

### DIFF
--- a/includes/usr.php
+++ b/includes/usr.php
@@ -55,7 +55,7 @@ class usrcp
     }
 
     //now our table, normal user system
-    public function normal($name, $pass, $hashed = false, $expire, $loginadm = false)
+    public function normal($name, $pass, $hashed, $expire, $loginadm = false)
     {
         global $SQL, $dbprefix, $config, $userinfo;
 


### PR DESCRIPTION
Optional parameter $hashed declared before required parameter $expire is implicitly treated as a required parameter